### PR TITLE
fix: fixed case when you could pass items to driver without any problems

### DIFF
--- a/src/controllers/inventory/inventories.nut
+++ b/src/controllers/inventory/inventories.nut
@@ -228,7 +228,7 @@ event("native:onPlayerTransferItem", function(playerid, id, slot) {
                     return msg(playerid, "inventory.transfer.largedistance");
                 }
 
-                if(!players[targetid].hands.isFreeSpace(1)) {
+                if(!players[targetid].hands.isFreeSpace(1) || isPlayerVehicleDriver(targetid)) {
                            msg(playerid, "inventory.transfer.targethandsbusy", getKnownCharacterNameWithId(playerid, targetid), CL_THUNDERBIRD);
                     return msg(targetid, "inventory.transfer.handsbusy", getKnownCharacterNameWithId(targetid, playerid), CL_THUNDERBIRD);
                 }


### PR DESCRIPTION
Исправлена проблема, когда будучи за рулем игрок мог получать от других игроков любые предметы через кнопку "Передать". При этом, пассажиры все еще могут получать предметы этим способом