### PR TITLE
fix: fixed case when car owner could start engine through theft

### DIFF
--- a/src/controllers/vehicle/index.nut
+++ b/src/controllers/vehicle/index.nut
@@ -226,7 +226,8 @@ key(["f"], function(playerid) {
         })
         return;
     }
-
+    local driverId = getVehicleDriver(vehicleid);
+    if (driverId != null && !isPlayerHaveVehicleKey(driverId, vehicleid)) return;
     unblockVehicle(vehicleid);
     setVehicleEngineState(vehicleid, true)
     delayedFunction(100, function() {


### PR DESCRIPTION
Исправил баг при котором владелец мог завести двигатель для игрока, сидящего внутри без ключа.